### PR TITLE
add metadata.version

### DIFF
--- a/finish/devfileV2.yaml
+++ b/finish/devfileV2.yaml
@@ -1,6 +1,7 @@
 schemaVersion: 2.3.0
 metadata:
   name: sample-cics-api
+  version: 2.0.0
 attributes:
   controller.devfile.io/storage-type: ephemeral
 projects:

--- a/start/devfileV2.yaml
+++ b/start/devfileV2.yaml
@@ -1,6 +1,7 @@
 schemaVersion: 2.3.0
 metadata:
   name: sample-cics-api
+  version: 2.0.0
 attributes:
   controller.devfile.io/storage-type: ephemeral
 projects:


### PR DESCRIPTION
Update `devfileV2.yaml` in both `start/` and `finish/` projects to include missing `metadata.version` field which is preventing the z/OS Connect Designer from being started in the RedHat OpenShift DevSpaces workspace.